### PR TITLE
[fix] 예외 throw 시 동적인 예외 메시지를 담을 수 있도록 수정

### DIFF
--- a/src/main/java/com/sinse/universe/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sinse/universe/advice/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e) {
-        log.error("CustomException 발생 - code: {}, message: {}", e.getErrorCode(), e.getErrorCode().getDetail(), e);
+        log.error("CustomException 발생 - code: {}, message: {}", e.getErrorCode(), e.getMessage(), e);
         return ApiResponse.error(e.getErrorCode());
     }
 

--- a/src/main/java/com/sinse/universe/exception/CustomException.java
+++ b/src/main/java/com/sinse/universe/exception/CustomException.java
@@ -13,8 +13,16 @@ public class CustomException extends RuntimeException{
         this.errorCode = errorCode;
     }
 
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
     public CustomException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getDetail(), cause);
         this.errorCode = errorCode;
     }
 }
+
+// 개발자가 동적으로 추가 정보를 전달하고 싶은 경우 message로 전달
+// exception의 message는 서버 로그로 찍히고, ErrorCode의 detail은 프론트에서 사용


### PR DESCRIPTION
- ErrorCode의 detail - 프론트 사용자에게 보여줄 메시지 
- CustomException의 message - 서버 로그에 찍을(개발자에게 보여줄) 메시지로, 사용자에게 보여줄 메시지와 별개로 출력하고 싶은 로그가 있는 경우 사용
(예외 메시지를 전달하지 않는 경우에는 서버 로그에 ErrorCode의 detail이 찍힘) 
### 리뷰 요청 
CustomException 봐주세요!  
