### PR TITLE
[feat] 유저 Oauth 로그인, 검증, 로그아웃 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/sinse/universe/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sinse/universe/advice/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e) {
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
         log.error("CustomException 발생 - code: {}, message: {}", e.getErrorCode(), e.getMessage(), e);
         return ApiResponse.error(e.getErrorCode());
     }
@@ -83,7 +83,7 @@ public class GlobalExceptionHandler {
      * 잡히지 않은 예외가 있는 경우에도 로그에 찍히도록 보장
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("Unhandled Exception 발생", e);
         return ApiResponse.error(ErrorCode.UNHANDLED_EXCEPTION);
     }

--- a/src/main/java/com/sinse/universe/config/WebConfig.java
+++ b/src/main/java/com/sinse/universe/config/WebConfig.java
@@ -21,6 +21,15 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${upload.base-dir}")
     private String baseDir;
 
+    @Value("${app.front-server.user.url}")
+    private String frontUserServerUrl;
+
+    @Value("${app.front-server.partner.url}")
+    private String frontPartnerServerUrl;
+
+    @Value("${app.front-server.admin.url}")
+    private String frontAdminServerUrl;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         // 예: /uploads/** → file:///C:/upload/
@@ -34,8 +43,9 @@ public class WebConfig implements WebMvcConfigurer {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**") // 모든 요청 경로 허용
-                        .allowedOrigins("http://localhost:5555") // 프론트 개발 서버
+                        .allowedOrigins(frontUserServerUrl, frontPartnerServerUrl, frontAdminServerUrl) // 프론트 서버들
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")   // 헤더에 accessToken 정보가 담겨오기 때문에 허용
                         .allowCredentials(true); // 인증정보(쿠키) 포함 허용 여부
             }
         };

--- a/src/main/java/com/sinse/universe/controller/AuthController.java
+++ b/src/main/java/com/sinse/universe/controller/AuthController.java
@@ -1,0 +1,79 @@
+package com.sinse.universe.controller;
+
+import com.sinse.universe.dto.request.EmailSendRequest;
+import com.sinse.universe.dto.request.EmailVerifyRequest;
+import com.sinse.universe.dto.request.UserJoinRequest;
+import com.sinse.universe.dto.response.ApiResponse;
+import com.sinse.universe.dto.response.TokenPair;
+import com.sinse.universe.model.auth.AuthServiceImpl;
+import com.sinse.universe.util.CookieUtil;
+import com.sinse.universe.util.JwtUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * 로그인, 인증 관련 요청을 처리하는 컨트롤러
+ */
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthServiceImpl authService;
+    private final JwtUtil jwtUtil;
+
+    // access token 만료 시 재발급 api
+    @PostMapping("/api/auth/accessToken")
+    public ResponseEntity<ApiResponse<Object>> reissueToken(
+            @CookieValue(name = "refreshToken") String refreshToken
+    ) {
+        TokenPair tokenPair = authService.reissueTokens(refreshToken);
+        ResponseCookie cookie = CookieUtil.setResponseCookie(tokenPair.refreshToken(), jwtUtil.getRefreshTokenTtl());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(new ApiResponse<>(true, "새 access token 발급 성공", null, Map.of("accessToken", tokenPair.accessToken())));
+    }
+
+    // 로그아웃 시 refreshtoken 제거
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = "refreshToken") String refreshToken
+    ) {
+        authService.logout(refreshToken);
+        ResponseCookie cookie = CookieUtil.setResponseCookie("", Duration.ZERO);
+
+        log.debug("로그아웃 요청");
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(new ApiResponse<>(true, "로그아웃 성공", null, null));
+    }
+
+    // 이메일 인증 코드 발송 api
+    @PostMapping("/api/auth/verification-emails")
+    public ResponseEntity<ApiResponse<Void>> sendEmailCode(@Valid @RequestBody EmailSendRequest request) {
+        authService.sendVerificationCode(request.getEmail());
+        return ApiResponse.success("인증 코드가 발송되었습니다. 이메일을 확인해주세요.");
+    }
+
+    @PostMapping("/api/auth/verify")
+    public ResponseEntity<ApiResponse<Void>> verifyEmail(@Valid @RequestBody EmailVerifyRequest request) {
+        authService.verifyEmail(request.getEmail(), request.getInputCode());
+        return ApiResponse.success("인증되었습니다. 회원가입을 진행해 주세요.");
+    }
+
+    @PostMapping("/api/ent/auth/join")
+    public ResponseEntity<ApiResponse<Void>> join(@RequestBody @Valid UserJoinRequest request) {
+        authService.join(request);
+        return ApiResponse.success("회원가입이 완료되었습니다. 다시 로그인 해주세요.");
+    }
+}

--- a/src/main/java/com/sinse/universe/domain/Partner.java
+++ b/src/main/java/com/sinse/universe/domain/Partner.java
@@ -30,3 +30,4 @@ public class Partner {
     private List<Artist> artists;
 }
 
+

--- a/src/main/java/com/sinse/universe/domain/PartnerUser.java
+++ b/src/main/java/com/sinse/universe/domain/PartnerUser.java
@@ -1,0 +1,29 @@
+package com.sinse.universe.domain;
+
+import com.sinse.universe.enums.PartnerRole;
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "PARTNER_USER")   // 소속사 관계자
+public class PartnerUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PT_US_ID")
+    private int id;
+
+    @Column(name = "PT_ROLE", nullable = false)
+    @Enumerated(EnumType.STRING) // String은 "SUPER, MANAGER"로 매핑, EnumType.ORDINAL 0, 1, 2 숫자로 저장됨
+    private PartnerRole role;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "UR_ID", nullable = false)  //DB 컬럼명
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PT_ID", nullable = false)
+    private Partner partner;
+
+}

--- a/src/main/java/com/sinse/universe/domain/Role.java
+++ b/src/main/java/com/sinse/universe/domain/Role.java
@@ -1,0 +1,21 @@
+package com.sinse.universe.domain;
+
+import com.sinse.universe.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "ROLE")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "RO_ID")
+    private int id;
+
+    @Column(name = "RO_NAME", nullable = false, unique = true)
+    @Enumerated(EnumType.STRING)
+    private UserRole name;
+
+}

--- a/src/main/java/com/sinse/universe/domain/User.java
+++ b/src/main/java/com/sinse/universe/domain/User.java
@@ -1,0 +1,50 @@
+package com.sinse.universe.domain;
+
+import com.sinse.universe.enums.UserStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name="USERS")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "UR_ID")
+    private int id;
+
+    @Column(name = "UR_EMAIL")
+    private String email;
+
+    @Column(name = "UR_PWD")
+    private String password;
+
+    @Column(name = "UR_PROVIDER")
+    private String provider;
+
+    @Column(name = "UR_OAUTH_ID")
+    private String oauthId;
+
+    @Column(name = "UR_NAME", nullable = false)
+    private String name;
+
+    @Column(name = "UR_STATUS", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    @Column(name = "UR_JOIN_DATE", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime joinDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "RO_ID", nullable = false)
+    private Role role;
+}

--- a/src/main/java/com/sinse/universe/dto/request/EmailSendRequest.java
+++ b/src/main/java/com/sinse/universe/dto/request/EmailSendRequest.java
@@ -1,0 +1,12 @@
+package com.sinse.universe.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailSendRequest {
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+}

--- a/src/main/java/com/sinse/universe/dto/request/EmailVerifyRequest.java
+++ b/src/main/java/com/sinse/universe/dto/request/EmailVerifyRequest.java
@@ -1,0 +1,16 @@
+package com.sinse.universe.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailVerifyRequest {
+
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    private String inputCode;
+
+}

--- a/src/main/java/com/sinse/universe/dto/request/UserJoinRequest.java
+++ b/src/main/java/com/sinse/universe/dto/request/UserJoinRequest.java
@@ -1,0 +1,28 @@
+package com.sinse.universe.dto.request;
+
+import com.sinse.universe.enums.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// record : 불변성 - 컴파일러 차원에서 강제 -> @Setter 추가 막음
+// @Getter @AllArgsConstructor @EqualsAndHashCode @ToString 기본 제공
+public record UserJoinRequest(
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일을 입력해주세요.")
+        String email,
+
+        // 보안 요구사항 있을 시 추가
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
+        String password,
+
+        @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+        String passwordConfirm,
+
+        @NotBlank(message = "이름을 입력해주세요.")
+        String name,
+
+        UserRole role
+){}
+

--- a/src/main/java/com/sinse/universe/dto/response/ApiResponse.java
+++ b/src/main/java/com/sinse/universe/dto/response/ApiResponse.java
@@ -43,7 +43,7 @@ public class ApiResponse<T> {
 
     // 성공응답 - 데이터 없음
     // 사용: ApiResponse.success(String msg)
-    public static <T> ResponseEntity<ApiResponse<T>> success(String message) {
+    public static ResponseEntity<ApiResponse<Void>> success(String message) {
         return success(message, null);
     }
 
@@ -67,10 +67,10 @@ public class ApiResponse<T> {
 
     // 실패응답
     // 사용: ApiResponse.error(ErrorCode ec, Object data)
-    public static ResponseEntity<ApiResponse<Object>> error(ErrorCode errorCode, Object data){
+    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorCode errorCode, T data){
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(ApiResponse.builder()
+                .body(ApiResponse.<T>builder()
                         .success(false)
                         .message(errorCode.getDetail())
                         .code(errorCode.name())
@@ -80,7 +80,7 @@ public class ApiResponse<T> {
     }
 
     // 사용: ApiResponse.error(ErrorCode ec)
-    public static ResponseEntity<ApiResponse<Object>> error(ErrorCode errorCode){
+    public static ResponseEntity<ApiResponse<Void>> error(ErrorCode errorCode){
         return error(errorCode, null);
     }
 }

--- a/src/main/java/com/sinse/universe/dto/response/TokenPair.java
+++ b/src/main/java/com/sinse/universe/dto/response/TokenPair.java
@@ -1,0 +1,6 @@
+package com.sinse.universe.dto.response;
+
+public record TokenPair (
+        String accessToken,
+        String refreshToken
+){ }

--- a/src/main/java/com/sinse/universe/enums/ErrorCode.java
+++ b/src/main/java/com/sinse/universe/enums/ErrorCode.java
@@ -4,18 +4,20 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
-    //--------------------------------------------------------------------------------------
-    //      400 BAD_REQUEST
-    //--------------------------------------------------------------------------------------
+    // 400 BAD_REQUEST
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
     PASSWORD_CONFIRM_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     ROLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 권한명입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "유저를 찾을 수 없습니다."),
 
     //verification = 이메일 인증
     VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
     NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일입니다. 인증을 시도해주세요"),
+
+    // 401
+    INVALID_REFRESHTOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token입니다."),
 
     // 소속사 Partner
     PARTNER_NOT_FOUND(HttpStatus.NOT_FOUND, "파트너를 찾을 수 없습니다."),
@@ -43,8 +45,8 @@ public enum ErrorCode {
     //--------------------------------------------------------------------------------------
     MAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다."),
 
-    UNHANDLED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unhandled Exception 발생"),
-    ;
+    UNHANDLED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unhandled Exception 발생");
+
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/sinse/universe/enums/PartnerRole.java
+++ b/src/main/java/com/sinse/universe/enums/PartnerRole.java
@@ -1,0 +1,7 @@
+package com.sinse.universe.enums;
+
+public enum PartnerRole {
+    ADMIN,
+    MANAGER
+}
+

--- a/src/main/java/com/sinse/universe/enums/UserRole.java
+++ b/src/main/java/com/sinse/universe/enums/UserRole.java
@@ -1,0 +1,8 @@
+package com.sinse.universe.enums;
+
+public enum UserRole {
+    USER,
+    PART,
+    ADMIN;
+}
+

--- a/src/main/java/com/sinse/universe/enums/UserStatus.java
+++ b/src/main/java/com/sinse/universe/enums/UserStatus.java
@@ -1,0 +1,17 @@
+package com.sinse.universe.enums;
+
+public enum UserStatus {
+    ACTIVE("활성"),       // enum 생성자
+    INACTIVE("비활성");
+
+    private final String description;
+
+    UserStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/src/main/java/com/sinse/universe/filter/JwtAuthFilter.java
+++ b/src/main/java/com/sinse/universe/filter/JwtAuthFilter.java
@@ -1,0 +1,78 @@
+package com.sinse.universe.filter;
+
+import com.sinse.universe.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.debug("jwtAuthFilter 진입");
+
+        String authz = request.getHeader("Authorization");
+        log.debug("authz 출력={}", authz);
+
+        // accessToken이 있는 경우만 검증, 없으면 필터를 그냥 거쳐서 Authentication이 없어서 시큐리티가 접근을 막는다.
+        if (authz != null && authz.startsWith("Bearer ") && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = authz.substring(7);
+            log.debug("token={}", token);
+            try {
+                Jws<Claims> jws = jwtUtil.validateToken(token);  //검증
+
+                Integer subject = Integer.valueOf(jws.getBody().getSubject());
+                String roleName = jws.getBody().get("role", String.class);
+                List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + roleName));
+
+                // 검증 성공 시 security context에 Authentication 저장
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(subject, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                log.debug("jwt 인증 성공");
+            } catch (ExpiredJwtException e) {
+                log.warn("JWT expired", e);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("{\"code\":\"TOKEN_EXPIRED\",\"message\":\"Access token expired\"}");  // 만료된 경우 프론트가 재발급 요청
+                return;
+            } catch (JwtException e){
+                log.warn("Invalid JWT", e);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("{\"code\":\"TOKEN_INVALID\",\"message\":\"Invalid token\"}");
+                return;
+            }
+        }
+
+        log.debug("jwt 필터 빠져나감");
+        filterChain.doFilter(request, response);
+    }
+
+    // 특정 경로에 대해 JwtAuthFilter가 동작하지 않도록 설정
+    // accessToken이 만료되어 재발급 요청을 보낼때 여전히 accessToken이 존재하므로, 컨트롤러에 진입하기 전에 ExpiredJwtException이 발생해 필터에서 튕겨버림
+    // 이것을 막고자 사용
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return request.getMethod().equals("POST")
+                && request.getRequestURI().equals("/api/auth/accessToken");
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/AuthServiceImpl.java
+++ b/src/main/java/com/sinse/universe/model/auth/AuthServiceImpl.java
@@ -1,0 +1,102 @@
+package com.sinse.universe.model.auth;
+
+import com.sinse.universe.domain.User;
+import com.sinse.universe.dto.request.UserJoinRequest;
+import com.sinse.universe.dto.response.TokenPair;
+import com.sinse.universe.enums.ErrorCode;
+import com.sinse.universe.exception.CustomException;
+import com.sinse.universe.model.user.UserRepository;
+import com.sinse.universe.model.user.UserServiceImpl;
+import com.sinse.universe.model.common.EmailServiceImpl;
+import com.sinse.universe.util.CodeGenerator;
+import com.sinse.universe.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl {
+
+    // 스프링 부트는 Duration 바인딩을 지원. (ms, s, m, h 등 단위 가능)
+    // email.verify.ttl=3m  -> 3분
+    @Value("${email.verification-code.ttl}")
+    private Duration verfiicationCodeTtl;
+
+    @Value("${email.verified-email.ttl}")
+    private Duration verifiedEmailTtl;
+
+    private final JwtUtil jwtUtil;
+    private final EmailServiceImpl emailService;
+    private final UserServiceImpl userService;
+    private final UserRepository userRepository;
+    private final VerificationEmailRepository verificationEmailRepository; //레디스 저장소
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenPair reissueTokens(String refreshToken) {
+
+        // 1. Redis에서 refreshToken 조회
+        String userId = refreshTokenRepository.find(refreshToken)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESHTOKEN));
+
+        // 검증 성공 시 새 토큰 발급 로직
+        User user = userRepository.findById(Integer.parseInt(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String newAccessToken = jwtUtil.createAccessToken(user.getId(), user.getRole().getName().name(), user.getEmail());
+        String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
+
+        refreshTokenRepository.delete(refreshToken);
+        refreshTokenRepository.save(newRefreshToken, userId, jwtUtil.getRefreshTokenTtl());
+
+        return new TokenPair(newAccessToken, newRefreshToken);
+    }
+
+    public void logout(String refreshToken) {
+        refreshTokenRepository.delete(refreshToken);
+    }
+
+    public void sendVerificationCode(String toEmail) {
+        userService.checkDuplicateEmail(toEmail);  //이메일 중복확인
+
+        // 인증 코드 생성, 전송 redis에 저장
+        String code = CodeGenerator.generate6DigitCode();
+        emailService.sendMail(toEmail, "Universe 인증 코드", code);
+        verificationEmailRepository.saveCode(toEmail, code, verfiicationCodeTtl);
+
+        log.info("이메일 인증 코드 전송 완료 - to={}, code={}", toEmail, code);
+    }
+
+    public void verifyEmail(String email, String inputCode){
+        // 코드 시간 만료
+        String storedCode = verificationEmailRepository.getCode(email)
+                .orElseThrow(()-> new CustomException(ErrorCode.VERIFICATION_CODE_EXPIRED));
+        // 코드 불일치
+        if(!storedCode.equals(inputCode)){
+            throw new CustomException(ErrorCode.VERIFICATION_CODE_INVALID);
+        }
+        verificationEmailRepository.saveVerifiedEmail(email, verifiedEmailTtl);
+        log.info("이메일 인증 코드 검증 성공 verified={}", email);
+    }
+
+    @Transactional
+    public void join(UserJoinRequest form) {
+        // 이메일 중복, 인증, 비밀번호 일치 검증
+        userService.checkDuplicateEmail(form.email());
+
+        if(!verificationEmailRepository.isVerified(form.email())){
+            throw new CustomException(ErrorCode.NOT_VERIFIED_EMAIL);
+        }
+        if (!form.password().equals(form.passwordConfirm())) {
+            throw new CustomException(ErrorCode.PASSWORD_CONFIRM_NOT_MATCH);
+        }
+
+        User user = userService.createGeneralUser(form);
+        log.info("회원가입 성공 user={}", user);
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/CustomOAuth2User.java
+++ b/src/main/java/com/sinse/universe/model/auth/CustomOAuth2User.java
@@ -1,0 +1,37 @@
+package com.sinse.universe.model.auth;
+
+import com.sinse.universe.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+// provider에게 받은 userInfo + DB 회원 정보를 함께 가지고 있는 객체
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    @Getter
+    private final User user;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return user.getOauthId(); //시큐리티 내부에서 사용할 식별값
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/sinse/universe/model/auth/CustomOAuth2UserService.java
@@ -1,0 +1,57 @@
+package com.sinse.universe.model.auth;
+
+import com.sinse.universe.domain.User;
+import com.sinse.universe.model.user.UserRepository;
+import com.sinse.universe.model.user.UserServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+
+// provider에게 userinfo를 받아서 DB 조회
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final UserServiceImpl userService;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // provider가 제공해준 user info를 담은 객체
+        OAuth2UserInfo userInfo = OAuth2UserInfo.of(provider, attributes)
+                .orElseThrow(() -> new RuntimeException("지원하지 않는 provider=" + provider));
+
+        // 기존 회원이 아니라면 강제 가입
+        User user = userRepository.findByProviderAndOauthId(provider, userInfo.oauth_id())
+                .orElseGet(()-> userService.createOAuthUser(provider, userInfo));
+
+        // 기존 회원이라면. 혹시 이메일, 닉네임이 변경되었다면 최신으로 수정
+        // JPA dirty checking - 수정사항이 있으면 DB에 자동 반영
+        user.setEmail(userInfo.email());
+        user.setName(userInfo.name());
+
+        return new CustomOAuth2User(
+                user,
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getName())),
+                attributes
+        );
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/OAuth2FailureHandler.java
+++ b/src/main/java/com/sinse/universe/model/auth/OAuth2FailureHandler.java
@@ -1,0 +1,30 @@
+package com.sinse.universe.model.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Value("${app.front-server.user.url}")
+    private String baseUrl;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("OAuth2 로그인 실패: {}", exception.getMessage());
+
+        String redirectUrl = baseUrl + "/login?error=INVALID_CREDENTIALS";
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sinse/universe/model/auth/OAuth2SuccessHandler.java
@@ -1,0 +1,53 @@
+package com.sinse.universe.model.auth;
+
+import com.sinse.universe.util.CookieUtil;
+import com.sinse.universe.util.JwtUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${app.front-server.user.url}")
+    private String baseUrl;
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        // oauth provider가 전달한 유저 정보가 Authentication에 담긴 상태(구현체인 OAuth2AuthenticationToken)
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();  // CustomOAuth2UserService에서 반환해준 객체
+
+        // JWT 토큰 발급
+        int userId = oAuth2User.getUser().getId();
+        String roleName = oAuth2User.getUser().getRole().getName().name();
+        String email = oAuth2User.getUser().getEmail();
+        String accessToken = jwtUtil.createAccessToken(userId, roleName, email);
+        String refreshToken = jwtUtil.createRefreshToken(userId);
+
+        // refresh token을 쿠키와 redis에 저장
+        refreshTokenRepository.save(refreshToken, String.valueOf(userId), jwtUtil.getRefreshTokenTtl());
+        ResponseCookie refreshCookie = CookieUtil.setResponseCookie(refreshToken, jwtUtil.getRefreshTokenTtl());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+
+        String redirectUrl = baseUrl + "/callback?accessToken=" + accessToken;
+        response.sendRedirect(redirectUrl);
+
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/OAuth2UserInfo.java
+++ b/src/main/java/com/sinse/universe/model/auth/OAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.sinse.universe.model.auth;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * OAuth2 provider별로 서로 다른 응답(JSON 구조)을 통일된 형태로 매핑
+ * @param oauth_id provider 내 사용자의 고유 식별자
+ * @param email    provider가 제공하는 email
+ * @param name     provider가 제공하는 name
+ */
+
+public record OAuth2UserInfo (
+        String oauth_id,
+        String email,
+        String name
+){
+    public static Optional<OAuth2UserInfo> of(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case "google" -> Optional.of(ofGoogle(attributes));
+            default -> Optional.empty();
+        };
+    }
+
+    private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+        return new OAuth2UserInfo(
+                (String) attributes.get("sub"),
+                (String) attributes.get("email"),
+                (String) attributes.get("name")
+        );
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/sinse/universe/model/auth/RefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.sinse.universe.model.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    //refreshToken:<refreshToken> <userId>
+    private static final String PREFIX = "refreshToken:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(String token, String userId, Duration ttl){
+        redisTemplate.opsForValue().set(PREFIX + token, userId, ttl);
+    }
+
+    public Optional<String> find(String token){
+        return Optional.ofNullable(redisTemplate.opsForValue().get(PREFIX + token));
+    }
+
+    public void delete(String token) {
+        redisTemplate.delete(PREFIX + token);
+    }
+}

--- a/src/main/java/com/sinse/universe/model/auth/VerificationEmailRepository.java
+++ b/src/main/java/com/sinse/universe/model/auth/VerificationEmailRepository.java
@@ -1,0 +1,34 @@
+package com.sinse.universe.model.auth;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+public class VerificationEmailRepository {
+
+    private final StringRedisTemplate redisTemplate;  // <String, String>
+    private static final String CODE_PREFIX = "verification:email-code:";
+    private static final String VERIFIED_EMAIL_PREFIX = "verified:email:";
+    public VerificationEmailRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void saveCode(String email, String code, Duration ttl){
+        redisTemplate.opsForValue().set(CODE_PREFIX + email, code, ttl);
+    }
+
+    public Optional<String> getCode(String email){
+        return Optional.ofNullable(redisTemplate.opsForValue().get(CODE_PREFIX + email));
+    }
+
+    public void saveVerifiedEmail(String email, Duration ttl) {
+        redisTemplate.opsForValue().set(VERIFIED_EMAIL_PREFIX + email, "true", ttl);
+    }
+
+    public boolean isVerified(String email){
+        return redisTemplate.hasKey(VERIFIED_EMAIL_PREFIX + email);
+    }
+}

--- a/src/main/java/com/sinse/universe/model/common/EmailServiceImpl.java
+++ b/src/main/java/com/sinse/universe/model/common/EmailServiceImpl.java
@@ -1,0 +1,44 @@
+package com.sinse.universe.model.common;
+
+import com.sinse.universe.enums.ErrorCode;
+import com.sinse.universe.exception.CustomException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+// 이메일 전송과 관련한 서비스
+@Service
+public class EmailServiceImpl {
+
+    @Value("${spring.mail.username}")
+    private String from;
+
+    private final JavaMailSender javaMailSender;
+
+    public EmailServiceImpl(JavaMailSender javaMailSender) {
+        this.javaMailSender = javaMailSender;
+    }
+
+    /**
+     * 메일 전송
+     * @param to       수신이메일
+     * @param subject  제목
+     * @param text     내용
+     */
+    public void sendMail(String to, String subject, String text) {
+        // 단순 텍스트 메일 (HTML 메일은 MimeMessage 사용)
+        SimpleMailMessage mail = new SimpleMailMessage();
+        mail.setTo(to);
+        mail.setSubject(subject);
+        mail.setText(text);
+        mail.setFrom(from);
+
+        try {
+            javaMailSender.send(mail);
+        } catch (MailException e) {
+            throw new CustomException(ErrorCode.MAIL_SEND_FAILED, e);
+        }
+    }
+}

--- a/src/main/java/com/sinse/universe/model/role/RoleRepository.java
+++ b/src/main/java/com/sinse/universe/model/role/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.sinse.universe.model.role;
+
+
+import com.sinse.universe.domain.Role;
+import com.sinse.universe.enums.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Integer> {
+    Optional<Role> findByName(UserRole name);
+}

--- a/src/main/java/com/sinse/universe/model/role/RoleServiceImpl.java
+++ b/src/main/java/com/sinse/universe/model/role/RoleServiceImpl.java
@@ -1,0 +1,22 @@
+package com.sinse.universe.model.role;
+
+import com.sinse.universe.domain.Role;
+import com.sinse.universe.enums.ErrorCode;
+import com.sinse.universe.enums.UserRole;
+import com.sinse.universe.exception.CustomException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoleServiceImpl {
+
+    private final RoleRepository roleRepository;
+
+    public RoleServiceImpl(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    public Role findByName(UserRole name) {
+        return roleRepository.findByName(name)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROLE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sinse/universe/model/user/UserRepository.java
+++ b/src/main/java/com/sinse/universe/model/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sinse.universe.model.user;
+
+import com.sinse.universe.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    boolean existsByEmail(String email);
+    Optional<User> findByProviderAndOauthId(String provider, String oauthId);
+}

--- a/src/main/java/com/sinse/universe/model/user/UserServiceImpl.java
+++ b/src/main/java/com/sinse/universe/model/user/UserServiceImpl.java
@@ -1,0 +1,59 @@
+package com.sinse.universe.model.user;
+
+import com.sinse.universe.domain.User;
+import com.sinse.universe.dto.request.UserJoinRequest;
+import com.sinse.universe.enums.ErrorCode;
+import com.sinse.universe.enums.UserRole;
+import com.sinse.universe.enums.UserStatus;
+import com.sinse.universe.exception.CustomException;
+import com.sinse.universe.model.auth.OAuth2UserInfo;
+import com.sinse.universe.model.role.RoleServiceImpl;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserServiceImpl {
+
+    private final RoleServiceImpl roleService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserServiceImpl(RoleServiceImpl roleService, UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.roleService = roleService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void checkDuplicateEmail(String email){
+        if(userRepository.existsByEmail(email)){
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    @Transactional
+    public User createGeneralUser(UserJoinRequest form) {
+        User user = User.builder()
+                .email(form.email())
+                .name(form.name())
+                .password(passwordEncoder.encode(form.password())) // 암호화
+                .role(roleService.findByName(form.role()))
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    public User createOAuthUser(String provider, OAuth2UserInfo userInfo) {
+        User user = User.builder()
+                .provider(provider)
+                .email(userInfo.email())
+                .oauthId(userInfo.oauth_id())
+                .name(userInfo.name())
+                .status(UserStatus.ACTIVE)
+                .role(roleService.findByName(UserRole.USER))
+                .build();
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/sinse/universe/security/SecurityConfig.java
+++ b/src/main/java/com/sinse/universe/security/SecurityConfig.java
@@ -1,0 +1,63 @@
+package com.sinse.universe.security;
+
+import com.sinse.universe.filter.JwtAuthFilter;
+import com.sinse.universe.model.auth.OAuth2FailureHandler;
+import com.sinse.universe.model.auth.OAuth2SuccessHandler;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final JwtAuthFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(Customizer.withDefaults())   // WebConfig의 Cors 설정이 적용되도록함
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        //로그인 관련 (OAuth2, 토큰 재발급 등)
+                        .requestMatchers("/oauth2/**", "/api/auth/**").permitAll()
+                        //.requestMatchers().permitAll() //API 요청 중 인증이 필요없는 공개 api
+                        .requestMatchers("/api/**").authenticated()
+                        //.anyRequest().permitAll()   // 개발할때만 잠깐 열어둘 용도로 모든 요청 허용
+                        .anyRequest().authenticated()
+                )
+                //스프링이 자동으로 "로그인 요청 -> 리다이렉트 -> 토큰 교환 -> 사용자 정보 조회" 과정을 처리해줌
+                .oauth2Login(oauth2->oauth2    //oauth2 로그인 기능 활성화
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
+                )
+                // 로그인 안돼있는 경우 구글로그인 리다이렉트되는 것 막기
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, ex1) -> {
+                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            res.setContentType("application/json;charset=UTF-8");
+                            res.getWriter().write("{\"code\":\"UNAUTHORIZED\",\"message\":\"로그인이 필요합니다.\"}");
+                        })
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sinse/universe/util/CookieUtil.java
+++ b/src/main/java/com/sinse/universe/util/CookieUtil.java
@@ -1,0 +1,18 @@
+package com.sinse.universe.util;
+
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+public class CookieUtil {
+
+    public static ResponseCookie setResponseCookie(String token, Duration maxAge){
+        return ResponseCookie.from("refreshToken", token)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(maxAge)
+                .build();
+    }
+}

--- a/src/main/java/com/sinse/universe/util/JwtUtil.java
+++ b/src/main/java/com/sinse/universe/util/JwtUtil.java
@@ -1,0 +1,76 @@
+package com.sinse.universe.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtUtil {
+
+    private SecretKey key;
+    private String issuer;
+    private Duration accessTokenTtl;
+    @Getter
+    private Duration refreshTokenTtl;
+
+    public JwtUtil(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.issure}") String issuer,
+            @Value("${app.jwt.access-ttl}") Duration accessTokenTtl,
+            @Value("${app.jwt.refresh-ttl}") Duration refreshTokenTtl
+    ){
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.issuer = issuer;
+        this.accessTokenTtl = accessTokenTtl;
+        this.refreshTokenTtl = refreshTokenTtl;
+    }
+
+    public String createAccessToken(int memberId, String roleName, String email) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + accessTokenTtl.toMillis());
+
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setSubject(String.valueOf(memberId))
+                .setId(UUID.randomUUID().toString()) // 토큰 고유 ID
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .claim("role", roleName)
+                .claim("email", email)
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(int member_id) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + refreshTokenTtl.toMillis());
+
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setSubject(String.valueOf(member_id))
+                .setId(UUID.randomUUID().toString()) // 토큰 고유 ID
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .signWith(key)
+                .compact();
+    }
+
+    // 검증
+    public Jws<Claims> validateToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+}

--- a/src/test/java/com/sinse/universe/util/JwtUtilTest.java
+++ b/src/test/java/com/sinse/universe/util/JwtUtilTest.java
@@ -1,0 +1,28 @@
+package com.sinse.universe.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class JwtUtilTest {
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @Test
+    void accesstoken_유효시간확인() {
+
+        //assertEquals(Duration.ofMinutes(15), jwtUtil.getACCESS_TOKEN_TTL());
+    }
+
+    @Test
+    void refreshtoken_유효시간확인() {
+        //assertEquals(Duration.ofDays(7), jwtUtil.getREFRESH_TOKEN_TTL());
+    }
+
+}


### PR DESCRIPTION
### 변경사항 

- 프론트 서버 주소 하드코딩 수정했습니다. 
- 사용자 인증이 필요하지 않은 요청은 security config에 추가해주시면 돼요 
- 블랙리스트나 버전은 구현하지 않았고, 로그아웃하면 해당 세션에서만 로그아웃 됩니다.

### 간단한 시큐리티 흐름... 
프론트에서 로그인 클릭 시 바로 provider(google)의 주소로 Oauth인증 요청 -> 유저가 동의를 클릭하면  provider는 서버 주소로 `Authorization code`를 붙여 리다이렉트 -> Oauth2LoginAuthenticationFilter가 요청을 가로채 다시 provider에게  이 `code`를 가지고 유저의 정보(userinfo)를 요청 ->  provider가 응답 

여기까지 하면 Oauth2 인증이 완료되면 `Oauth2SuccessHandler` 작동함 -> 여기서 서버는 유저의 정보를 바탕으로 자체 JWT를 발급하여 프론트에 응답 (여기까지 Oauth2필터에서 동작함) 

로그인 이후 프론트에서는 모든 요청 헤더에 JWT access token를 담아 서버로 전달함 -> `JwtAuthFilter`에서 토큰을 검증. (로그인 이후의 요청은 oauth와 상관이 없다) 

그리고 인증에 성공한 요청만 Controller에 진입하여 우리가 만든 메서드를 실행하는것

closes #21 #29 #30  