### PR TITLE
[feat] #33 카카오페이 결제 api 연동

### DIFF
--- a/src/main/java/com/sinse/universe/controller/PaymentController.java
+++ b/src/main/java/com/sinse/universe/controller/PaymentController.java
@@ -1,0 +1,51 @@
+package com.sinse.universe.controller;
+
+import com.sinse.universe.domain.Order;
+import com.sinse.universe.model.order.OrderRepository;
+import com.sinse.universe.model.payment.ApproveResponse;
+import com.sinse.universe.model.payment.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PaymentController {
+
+    @Value("${app.front-server.user.url}")
+    private String userFrontServer;
+    private final PaymentService paymentService;
+    private final OrderRepository orderRepository;
+
+
+    @GetMapping("/payment/success")
+    public RedirectView approve(
+            @RequestParam("pg_token") String pgToken,
+            @RequestParam("order_id") int orderId
+    ) {
+        // 사용자가 결제 qr을 통해 확인 버튼을 클릭하면 결제승인 api를 호출해 최종적으로 결제 승인을 해야함
+
+        Order order = orderRepository.findById(orderId).get();
+        ApproveResponse response = paymentService.approve(pgToken, order);
+
+        RedirectView redirectView = new RedirectView();
+        redirectView.setUrl(userFrontServer + "/order/paid/" + orderId);
+        return redirectView;
+    }
+
+    @GetMapping("/payment/cancel")
+    public String cancelPayment() {
+        return "취소 -_-";
+    }
+
+    @GetMapping("/payment/fail")
+    public String failPayment() {
+        return "실..패!";
+    }
+}

--- a/src/main/java/com/sinse/universe/controller/StreamController.java
+++ b/src/main/java/com/sinse/universe/controller/StreamController.java
@@ -4,6 +4,7 @@ import com.sinse.universe.domain.Stream;
 import com.sinse.universe.dto.request.StreamRequest;
 import com.sinse.universe.dto.response.ApiResponse;
 import com.sinse.universe.dto.response.StreamResponse;
+import com.sinse.universe.enums.StreamStatus;
 import com.sinse.universe.model.stream.StreamService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -86,5 +87,19 @@ public class StreamController {
         return streamService.findByArtistId(artistId, pageable)
                 .map(StreamResponse::from);
     }
+
+
+    // 종료된 스트림만 가져오기
+    @GetMapping("/artists/{artistId}/streams/ended")
+    public List<StreamResponse> getEnded(
+            @PathVariable int artistId
+    ) {
+        return streamService.findByArtistId(artistId)
+                .stream()
+                .filter(stream -> stream.getStatus() == StreamStatus.ENDED)
+                .map(StreamResponse::from)
+                .toList();
+    }
+
 }
 

--- a/src/main/java/com/sinse/universe/domain/Order.java
+++ b/src/main/java/com/sinse/universe/domain/Order.java
@@ -3,6 +3,7 @@ package com.sinse.universe.domain;
 import com.sinse.universe.enums.OrderStatus;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -81,5 +82,6 @@ public class Order {
 
     // OrderItem 매핑하기
     @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ToString.Exclude
     private List<OrderProduct> orderProducts = new ArrayList<>();
 }

--- a/src/main/java/com/sinse/universe/enums/OrderStatus.java
+++ b/src/main/java/com/sinse/universe/enums/OrderStatus.java
@@ -1,6 +1,7 @@
 package com.sinse.universe.enums;
 
 public enum OrderStatus {
+    PENDING("결제 대기"),
     PAID("주문 완료"),       // enum 생성자
     CANCELED("주문 취소"),
     SHIPPING("배송 중"),

--- a/src/main/java/com/sinse/universe/model/order/OrderService.java
+++ b/src/main/java/com/sinse/universe/model/order/OrderService.java
@@ -1,5 +1,6 @@
 package com.sinse.universe.model.order;
 
+import com.sinse.universe.domain.Order;
 import com.sinse.universe.dto.request.OrderSubmitRequest;
 import com.sinse.universe.dto.response.OrderForEntResponse;
 import com.sinse.universe.dto.response.OrderForUserResponse;
@@ -16,5 +17,5 @@ public interface OrderService {
     // 유저 페이지) 주문 상세 요청
     public OrderForUserResponse getDetail(int orderId);
     // 유저 페이지) 주문 등록
-    public int submitOrder(OrderSubmitRequest request);
+    public Order submitOrder(OrderSubmitRequest request);
 }

--- a/src/main/java/com/sinse/universe/model/payment/ApproveResponse.java
+++ b/src/main/java/com/sinse/universe/model/payment/ApproveResponse.java
@@ -1,0 +1,49 @@
+package com.sinse.universe.model.payment;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ApproveResponse {
+    private String aid;
+    private String tid;
+    private String cid;
+    private String partner_order_id;
+    private String partner_user_id;
+    private String payment_method_type;
+    private Amount amount;
+    private String item_name;
+    private String item_code;
+    private String quantity;
+    private String created_at;
+    private String approved_at;
+    private String payload;
+
+    @Getter
+    @Setter
+    public static class Amount {
+        private Integer total;
+        private Integer tax_free;
+        private Integer vat;
+        private Integer point;
+        private Integer discount;
+        private Integer green_deposit;
+    }
+
+    @Getter @Setter
+    public static class CardInfo {
+        private String purchase_corp;
+        private String purchase_corp_code;
+        private String issuer_corp;
+        private String issuer_corp_code;
+        private String bin;
+        private String card_type;
+        private String install_month;
+        private String approved_id;
+        private String card_mid;
+        private String interest_free_install;
+        private String card_item_code;
+    }
+
+}

--- a/src/main/java/com/sinse/universe/model/payment/KakaoReadyResponse.java
+++ b/src/main/java/com/sinse/universe/model/payment/KakaoReadyResponse.java
@@ -1,0 +1,19 @@
+package com.sinse.universe.model.payment;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter
+@Getter
+@ToString
+public class KakaoReadyResponse {
+
+    private String tid;  //결제 고유 번호, 20자
+    private String next_redirect_app_url;  //요청한 client가 모바일 앱일 경우 카카오톡 결제 페이지 Redirect URL
+    private String next_redirect_mobile_url;  //요청한 client가 모바일 웹일 경우 카카오톡 결제 페이지 Redirect URL
+    private String next_redirect_pc_url;  //요청한 client가 pc 웹일 경우 카카오톡 결제 페이지 Redirect URL
+    private String android_app_scheme;
+    private String ios_app_scheme;
+    private String created_at;  //결제 준비 요청 시간
+}

--- a/src/main/java/com/sinse/universe/model/payment/PaymentRepository.java
+++ b/src/main/java/com/sinse/universe/model/payment/PaymentRepository.java
@@ -1,0 +1,22 @@
+package com.sinse.universe.model.payment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepository {
+
+    private static final String PREFIX = "kakao:payment:";   //kakao:payment:{status}:{orderId}
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(String orderId, String tid, Duration ttl){
+        redisTemplate.opsForValue().set(PREFIX + orderId, tid, ttl);
+    }
+    public String get(String orderId){
+        return redisTemplate.opsForValue().get(PREFIX + orderId);
+    }
+}

--- a/src/main/java/com/sinse/universe/model/payment/PaymentService.java
+++ b/src/main/java/com/sinse/universe/model/payment/PaymentService.java
@@ -1,0 +1,154 @@
+package com.sinse.universe.model.payment;
+
+import com.sinse.universe.domain.Membership;
+import com.sinse.universe.domain.Order;
+import com.sinse.universe.domain.OrderProduct;
+import com.sinse.universe.domain.Product;
+import com.sinse.universe.enums.OrderStatus;
+import com.sinse.universe.model.cart.CartRepository;
+import com.sinse.universe.model.membership.MembershipRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * 카카오페이 결제 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final CartRepository cartRepository;
+    private final MembershipRepository membershipRepository;
+    @Value("${kakaopay.cid}")
+    private String cid;
+
+    @Value("${kakaopay.dev.secretKey}")
+    private String secretKey;
+
+    private RestTemplate restTemplate;  //외부 서버로 api 요청 보내기 위해 사용
+    private final PaymentRepository paymentRepository;
+
+    // 카카오가 요구하는 형식의 HTTP header 생성
+    private HttpHeaders getHeaders(){
+        HttpHeaders headers = new HttpHeaders();
+        String auth = "SECRET_KEY " + secretKey;
+
+        headers.set("Authorization", auth);
+        headers.set("Content-Type", "application/json");
+        return headers;
+    }
+
+    // 1. 결제 요청
+    @Transactional
+    public KakaoReadyResponse requestKakaoPayReady(Order order) {
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, Object> params = new HashMap<>();
+
+        params.put("cid", cid);                                             // 가맹점 코드 10자 (client id 아님), test 결제는 코드가 정해져 있음
+        params.put("partner_order_id", order.getNo());                      // 가맹점 주문번호, 최대 100자
+        params.put("partner_user_id", order.getUser().getId());             // 가맹점 회원 id, 최대 100자 (개인정보 X - 그냥 유저를 식별할수만 있으면 됨)
+        params.put("item_name", buildItemName(order));                      // 상품명, 최대 100자
+        params.put("quantity", order.getOrderProducts().size());            // 상품 종류별 수량을 다 합친 값
+        params.put("total_amount", order.getTotalPrice());                  // 결제 총액
+
+        params.put("tax_free_amount", "0");     // 상품 비과세 금액
+        params.put("approval_url", "http://localhost:7777/payment/success?order_id=" + order.getId());        // 결제 성공 시 redirect url, 최대 255자
+        params.put("cancel_url", "http://localhost:7777/payment/cancel");          // 결제 취소 시 redirect url
+        params.put("fail_url", "http://localhost:7777/payment/fail");
+
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(params, this.getHeaders());
+        log.debug("결제 http 요청 메시지 {}", requestEntity);
+
+        KakaoReadyResponse kakaoReadyResponse = restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/ready",
+                requestEntity,
+                KakaoReadyResponse.class
+        );
+
+        log.debug("카카오에서 보낸 응답 {}", kakaoReadyResponse);
+
+        // tid (결제 번호) 저장
+        paymentRepository.save(Integer.toString(order.getId()), kakaoReadyResponse.getTid(), Duration.ofMinutes(15));
+
+        return kakaoReadyResponse;
+    }
+
+    // 카카오 결제창에서 보여줄 상품명 ex) "블랙핑크 멤버십 외 N건"
+    private String buildItemName(Order order) {
+        List<OrderProduct> products = order.getOrderProducts();
+        String firstItemName = products.get(0).getProduct().getName();
+
+        return (products.size() > 1)
+                ? firstItemName + " 외 " + (products.size() - 1) + "건"
+                : firstItemName;
+    }
+
+    @Transactional
+    public ApproveResponse approve(String pgToken, Order order) {
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, String> params = new HashMap<>();
+
+        params.put("cid", cid);
+        params.put("tid", paymentRepository.get(Integer.toString(order.getId())));
+        params.put("partner_order_id", order.getNo());
+        params.put("partner_user_id", String.valueOf(order.getUser().getId()));
+        params.put("pg_token", pgToken);
+
+
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(params, getHeaders());
+
+        ApproveResponse response = restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/approve",
+                entity,
+                ApproveResponse.class
+        );
+
+        log.debug("kakao에게 받은 approve resopnse={}", response);
+
+        // Todo: 장바구니 삭제
+        List<Integer> productIds = order.getOrderProducts().stream()
+                .map(OrderProduct::getProduct)
+                .map(Product::getId)
+                .toList();
+
+        cartRepository.deleteByUser_IdAndProduct_IdIn(order.getUser().getId(), productIds);
+
+
+        // Todo: 멤버십 상품 체크 후 db insert
+        List<Product> membershipProductList = order.getOrderProducts().stream()
+                .map(OrderProduct::getProduct)
+                .filter(p -> "멤버십".equals(p.getCategory().getName()))
+                .toList();
+
+        membershipProductList.forEach(p -> {
+            Membership membership = new Membership();
+            membership.setUser(order.getUser());
+            membership.setArtist(p.getArtist());
+            LocalDate orderDate = order.getDate().toLocalDate();
+            membership.setStartDate(orderDate.atStartOfDay());
+            membership.setEndDate(orderDate.plusYears(1).atTime(23, 59, 59));
+
+            membershipRepository.save(membership);
+        });
+
+        // Todo: order status PAID로 변경
+        order.setStatus(OrderStatus.PAID);
+
+        return response;
+    }
+
+}

--- a/src/main/java/com/sinse/universe/model/stream/StreamRepository.java
+++ b/src/main/java/com/sinse/universe/model/stream/StreamRepository.java
@@ -5,7 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StreamRepository extends JpaRepository<Stream, Integer> {
     //    List<Stream> findByArtistId(Integer id);
     Page<Stream> findByArtistId(Integer artistId, Pageable pageable);
+    List<Stream> findByArtistId(Integer artistId);
 }

--- a/src/main/java/com/sinse/universe/model/stream/StreamService.java
+++ b/src/main/java/com/sinse/universe/model/stream/StreamService.java
@@ -14,6 +14,6 @@ public interface StreamService {
     public Stream regist(StreamRequest request) throws IOException;
     public Stream update(int id, StreamRequest request) throws IOException;
     public void delete(int streamId);
-//    public List<Stream> findByArtistId(int streamId);
+   public List<Stream> findByArtistId(int artistId);
     public Page<Stream> findByArtistId(int artistId, Pageable pageable);
 }

--- a/src/main/java/com/sinse/universe/model/stream/StreamServiceImpl.java
+++ b/src/main/java/com/sinse/universe/model/stream/StreamServiceImpl.java
@@ -158,6 +158,11 @@ public class StreamServiceImpl implements StreamService {
         return streamRepository.findByArtistId(artistId, pageable);
     }
 
+    @Override
+    public List<Stream> findByArtistId(int artistId) {
+        return streamRepository.findByArtistId(artistId);
+    }
+
     // 파일 저장 메서드
     private String saveFile(MultipartFile file, Integer streamId) throws IOException {
         String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();


### PR DESCRIPTION
### 흐름
 1. ready: 카카오페이 결제를 시작하기 위해 결제정보를 카카오페이 서버에 전달하고 결제 고유번호(TID)와 URL을 응답받는 단계.
 2. approve: 사용자가 결제 수단을 선택하고 비밀번호를 입력해 결제 인증을 완료한 뒤, 최종적으로 결제 완료 처리를 하는 단계.

결제하기 클릭 -> 서버가 카카오페이 ready api 호출 -> 카카오가 approval_url로 redirect -> 서버가 주문 완료 처리 및 카카오페이 approve api 호출 -> 서버가 프론트를 주문완료 페이지로 리다이렉트 하기 위한 응답 전송  

closes #33 
